### PR TITLE
fix: update livestreamService to use centralized BASE_URL instead of …

### DIFF
--- a/src/services/livestreamService.ts
+++ b/src/services/livestreamService.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
+import { BASE_URL } from '../consts/apiUrl/baseUrl';
 
 // Types for API requests and responses
 interface CreateLivestreamDto {
@@ -92,7 +93,7 @@ export { LivestreamStatus, UserRoleInCourse };
 class LivestreamApiService {
   private api: AxiosInstance;
 
-  constructor(baseUrl: string = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5001/api') {
+  constructor(baseUrl: string = BASE_URL) {
     this.api = axios.create({
       baseURL: baseUrl,
       headers: {


### PR DESCRIPTION
This pull request updates the `LivestreamApiService` to use a centralized API base URL constant instead of relying on environment variables or hardcoded values. This change improves maintainability and consistency in how the API base URL is managed.

API URL management:

* Imported the `BASE_URL` constant from `src/consts/apiUrl/baseUrl` into `src/services/livestreamService.ts`, replacing previous usage of environment variables and hardcoded defaults.
* Updated the `LivestreamApiService` constructor to use the `BASE_URL` constant for initializing the Axios instance.…env variable